### PR TITLE
Fix modal toggling at game start

### DIFF
--- a/game.js
+++ b/game.js
@@ -38,6 +38,7 @@ function resetGame() {
   dropBtn.disabled = true;
   // ensure the win modal is hidden when restarting
   modal.classList.add('hidden');
+  modal.style.display = 'none';
   prizeImg.src = '';
   prizeImg.style.backgroundColor = '';
 }
@@ -200,6 +201,7 @@ function update() {
         prizeImg.src = claw.grabbed.sprite;
         prizeImg.style.backgroundColor = '';
         modal.classList.remove('hidden');
+        modal.style.display = 'flex';
       }
     }
   }
@@ -239,5 +241,6 @@ dropBtn.addEventListener('click', () => {
 
 closeModal.addEventListener('click', () => {
   modal.classList.add('hidden');
+  modal.style.display = 'none';
   resetGame();
 });


### PR DESCRIPTION
## Summary
- ensure modal is hidden when resetting the game
- set display to flex when showing the prize modal
- hide modal properly on close

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684322e9d364832eba95e25b948dfc0d